### PR TITLE
Move rating bar table into email body.

### DIFF
--- a/email_template.html
+++ b/email_template.html
@@ -36,7 +36,7 @@
       </td>
     </tr>
     <tr>
-      <td>
+      <td style="text-align: justify;">
         <br>
         Hey Lisa,
         <br>
@@ -50,29 +50,25 @@
             <!-- Linking to emails here just makes sense. -->
         <br>
         <br>
-        Cheers,
-        <br>
-        <br>
-        Your Friendly Family Friday Facilitators <!-- <3 alliteration -->
-        <br>
-        <br>
       </td>
     </tr>
-    <tr>
+    <tr style="">
       <td>
-
         <table border="0"
                cellpadding="0"
                cellspacing="0"
                style="width: 100%;">
           <tbody>
             <tr>
-              <td style="width: 220;">
+              <td style="size: 7.45%">
+                &nbsp;&nbsp;&nbsp;&nbsp;
+              </td>
+              <td style="text-aign: center;">
                 <a href="https://www.yelp.com/biz/pizzas-r-us-birmingham">
-                <img src="http://i.imgur.com/RozeCeX.jpg"
+                <img src="http://i.imgur.com/5e99OvU.png"
                      alt="Pizza R Us Logo"
                      style="width: 220;
-                            height: 165;"> <!-- Since the payload didn't use
+                            height: 220;"> <!-- Since the payload didn't use
                                                 an actual logo or yelp link
                                                 I've grabbed some examples. -->
                 </a>
@@ -88,12 +84,12 @@
                                             Arial,
                                             sans-serif;
                               font-size: 18px;
-                              font-weight: 300;">
+                              font-weight: 400;">
                    <tbody>
                      <tr>
-                       <td colspan="2" style="text-align: center;">
-                         Rate <a href="https://www.yelp.com/biz/pizzas-r-us-birmingham">
-                                Pizza R Us</a> out of 5 stars.
+                       <td colspan="2" style="text-align: center;
+                                              font-size: 22px;">
+                         Click a star to rate Pizza R Us.
                        </td>
                      </tr>
                      <tr >
@@ -176,10 +172,23 @@
                 </table>
 
               </td>
+              <td style="size: 7.45%">
+                &nbsp;&nbsp;&nbsp;&nbsp;
+              </td>
             </tr>
           </tbody>
         </table>
-
+        </td>
+      </tr>
+    <tr>
+      <td>
+        <br>
+        Cheers,
+        <br>
+        <br>
+        Your Friendly Family Friday Facilitators <!-- <3 alliteration -->
+        <br>
+        <br>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
After soliciting feedback from some friends I decided to grab a better
example logo and move the clickable bar table into the email body and
increase the call to action, along with using the word click is more
clear. Paragraph is also justify-aligned now.